### PR TITLE
Stop polling after device deactivation

### DIFF
--- a/backend/src/oracle/ContractService.ts
+++ b/backend/src/oracle/ContractService.ts
@@ -96,5 +96,9 @@ export class ContractService {
   public static computeDeviceId(wotEndpoint: string): string {
     return ethers.keccak256(ethers.toUtf8Bytes(wotEndpoint));
   }
+
+  public getContractInstance(): ethers.Contract {
+    return this.contract;
+  }
 }
 

--- a/backend/src/oracle/DeviceMonitor.ts
+++ b/backend/src/oracle/DeviceMonitor.ts
@@ -9,6 +9,7 @@ export class DeviceMonitor {
   private thing: any = null;
   private heartbeatTimeout: NodeJS.Timeout | null = null;
   private isRunning: boolean = false;
+  private isActive: boolean = true;
 
   private readonly HEARTBEAT_MULTIPLIER = 1.5;
 
@@ -36,6 +37,11 @@ export class DeviceMonitor {
 
     await this.thing.subscribeEvent('heartbeat', async (data: any) => {
       if(!this.isRunning) return;
+
+      if (!this.isActive) {
+        console.log(`[DeviceMonitor ${this.wotEndpoint}] Skipping — device is inactive`);
+        return;
+      }
 
       console.log(`[DeviceMonitor] ${this.wotEndpoint} Heartbeat recevied`)
 
@@ -69,13 +75,27 @@ export class DeviceMonitor {
     console.log(`[DeviceMonitor ${this.wotEndpoint}] Stopped`);
   }
 
+  public markInactive(): void {
+    console.log(`[DeviceMonitor ${this.wotEndpoint}] Marked as inactive`);
+    this.isActive = false;
+
+    if (this.heartbeatTimeout) {
+      clearTimeout(this.heartbeatTimeout);
+      this.heartbeatTimeout = null;
+    }
+  }
+
+  public getDeviceId(): string {
+    return this.deviceId;
+  }
+
   private resetHeartbeatTimeout(): void {
     if (this.heartbeatTimeout) {
       clearTimeout(this.heartbeatTimeout);
     }
 
     this.heartbeatTimeout = setTimeout(async () => {
-      if(!this.isRunning) return;
+      if(!this.isRunning || !this.isActive) return;
 
       console.warn(`[DeviceMonitor ${this.wotEndpoint}] Heartbeat timeout -- device offline`);
 

--- a/backend/src/oracle/OracleManager.ts
+++ b/backend/src/oracle/OracleManager.ts
@@ -14,12 +14,15 @@ export class OracleManager {
     console.log(`Starting monitors for ${deviceConfigs.length} devices`);
 
     for (const config of deviceConfigs) {
-      const endpoint = `http://localhost:${config.port}/${config.id}`
+      const endpoint = `http://localhost:${config.port}/${config.id}`;
+      const deviceId = ContractService.computeDeviceId(endpoint);
 
       const monitor = new DeviceMonitor(endpoint, this.contractService, config);
       await monitor.start()
-      this.monitors.set(config.id, monitor);
+      this.monitors.set(deviceId, monitor);
     }
+
+    this.listenForDeactivations();
     console.log(`All monitors running`);
   }
 
@@ -28,5 +31,17 @@ export class OracleManager {
     Array.from(this.monitors.values()).forEach((monitor) => monitor.stop());
 
     this.monitors.clear();
+  }
+
+  private listenForDeactivations(): void {
+    const contract = this.contractService.getContractInstance();
+    
+    contract.on("DeviceDeactivated", (deviceId: string) => {
+      const monitor = this.monitors.get(deviceId);
+      if (monitor) {
+        monitor.markInactive();
+        console.log(`Monitor marked inactive for ${deviceId}.`);
+      }
+    });
   }
 }


### PR DESCRIPTION
This pull request enhances device monitoring and contract integration in the backend. The main changes introduce a mechanism to handle device deactivation events from the contract, improve device monitor state management, and refine how monitors are tracked and identified.

**Device deactivation handling and monitor management:**

* The `OracleManager` now listens for `DeviceDeactivated` events from the contract and marks the corresponding `DeviceMonitor` as inactive when such an event occurs, improving synchronization between contract state and device monitoring.
* Device monitors are now keyed by their computed device ID (from `ContractService.computeDeviceId(endpoint)`) instead of a simple config ID, ensuring consistent identification between contract events and monitor instances.

**Device monitor state management:**

* Added an `isActive` property to `DeviceMonitor` and logic to skip heartbeat processing if the device is inactive, preventing unnecessary operations on deactivated devices.
* Introduced a `markInactive` method in `DeviceMonitor` to set the monitor as inactive, clear heartbeat timeouts, and log the state change.
* Heartbeat timeout logic now also checks if the device is active before proceeding, further aligning monitor behavior with device state.

**Contract service improvements:**

* Added a `getContractInstance` method to `ContractService` for easier and safer access to the contract instance from other classes.