### PR TITLE
Allow generic sensor usage

### DIFF
--- a/backend/src/oracle/DeviceMonitor.ts
+++ b/backend/src/oracle/DeviceMonitor.ts
@@ -1,7 +1,6 @@
 import Servient from "@node-wot/core";
 import { ContractService } from "./ContractService";
 import { HttpClientFactory } from "@node-wot/binding-http";
-import { DeviceConfig, PLAUSIBILITY_BOUNDS } from "../wot/deviceConfig";
 
 export class DeviceMonitor {
   private deviceId: string;
@@ -12,12 +11,13 @@ export class DeviceMonitor {
   private isActive: boolean = true;
   private lastSeenEventId: number = 0;
 
+  private dynamicIntervalMs: number = 15000;
   private readonly HEARTBEAT_MULTIPLIER = 1.5;
 
   public constructor(
     private wotEndpoint: string, 
-    private contractService: ContractService,
-    private deviceConfig: DeviceConfig) {
+    private contractService: ContractService
+  ) {
       this.deviceId = ContractService.computeDeviceId(wotEndpoint);
       this.servient = new Servient();
       this.servient.addClientFactory(new HttpClientFactory);
@@ -31,6 +31,14 @@ export class DeviceMonitor {
 
     const td = await WoT.requestThingDescription(this.wotEndpoint);
     this.thing = await WoT.consume(td);
+
+    try {
+      const rawInterval = await this.thing.readProperty('heartbeatInterval');
+      this.dynamicIntervalMs = await rawInterval.value();
+      console.log(`[DeviceMonitor ${this.wotEndpoint}] Bound heartbeat interval to ${this.dynamicIntervalMs}ms`);
+    } catch (error) {
+      console.warn(`[DeviceMonitor ${this.wotEndpoint}] Failed to read heartbeatInterval. Falling back to 15s.`);
+    }
 
     console.log(`[DeviceMonitor ${this.wotEndpoint}] Connected. Starting Monitoring`);
 
@@ -107,6 +115,8 @@ export class DeviceMonitor {
       clearTimeout(this.heartbeatTimeout);
     }
 
+    const timeoutThreshold = this.dynamicIntervalMs * this.HEARTBEAT_MULTIPLIER;
+
     this.heartbeatTimeout = setTimeout(async () => {
       if(!this.isRunning || !this.isActive) return;
 
@@ -118,36 +128,59 @@ export class DeviceMonitor {
       await this.contractService.submitAvailabilityReport(this.deviceId, false, missingEventId);
 
       this.resetHeartbeatTimeout();
-    }, this.HEARTBEAT_MULTIPLIER * this.deviceConfig.heartbeatInterval); 
+    }, timeoutThreshold); 
   }
 
   private async evaluateAccuracy(eventId: number): Promise<void> {
     try {
-      const temperatureRaw = await this.thing.readProperty('temperature');
-      const humidityRaw = await this.thing.readProperty('humidity');
+      let accurate = true;
+      const td = await this.thing.getThingDescription();
 
-      const temperature = await temperatureRaw.value();
-      const humidity = await humidityRaw.value();
-
-      console.log(`[DeviceMonitor ${this.wotEndpoint}] temperature: ${temperature}, humidity: ${humidity}`);
-
-      const temperatureVaild = temperature >= PLAUSIBILITY_BOUNDS.temperature.min &&
-                                temperature <= PLAUSIBILITY_BOUNDS.temperature.max;
-
-      const humidityVaild = humidity >= PLAUSIBILITY_BOUNDS.humidity.min &&
-                            humidity <= PLAUSIBILITY_BOUNDS.humidity.max;
-
-      const accurate = temperatureVaild && humidityVaild;
-
-      if (!accurate) {
-        console.log(`[DeviceMonitor ${this.wotEndpoint}] Inaccurate reading detected - ` +
-          `temperature: ${temperature}, humidity: ${humidity}`
-         )
+      if (!td.properties) {
+         console.warn(`[DeviceMonitor ${this.wotEndpoint}] No properties found in TD to evaluate.`);
+         return;
       }
 
-      this.contractService.submitAccuracyReport(this.deviceId, accurate, eventId);
+      for (const propName of Object.keys(td.properties)) {
+        const propSchema = td.properties[propName];
+
+        if (propSchema.type === 'number' || propSchema.type === 'integer') {
+          let value: number;
+
+          try {
+            const rawValue = await this.thing.readProperty(propName);
+            value = await rawValue.value(); 
+          } catch (validationError: any) {
+            console.log(`[DeviceMonitor ${this.wotEndpoint}] W3C Schema Violation on '${propName}': Device output rejected by W3C validator.`);
+            accurate = false;
+            continue;
+          }
+
+          const min = propSchema.minimum;
+          const max = propSchema.maximum;
+
+          if (min !== undefined && value < min) {
+             console.log(`[DeviceMonitor ${this.wotEndpoint}] Inaccurate reading: '${propName}' value ${value} is below minimum ${min}`);
+             accurate = false;
+          }
+          
+          if (max !== undefined && value > max) {
+             console.log(`[DeviceMonitor ${this.wotEndpoint}] Inaccurate reading: '${propName}' value ${value} is above maximum ${max}`);
+             accurate = false;
+          }
+        }
+      }
+
+      if (accurate) {
+        console.log(`[DeviceMonitor ${this.wotEndpoint}] All property readings are within acceptable bounds.`);
+      } else {
+        console.log(`[DeviceMonitor ${this.wotEndpoint}] Device penalized for anomalous readings.`);
+      }
+
+      await this.contractService.submitAccuracyReport(this.deviceId, accurate, eventId);
+      
     } catch (error) {
-      console.error(`[DeviceMonitor ${this.wotEndpoint}] Failed to read device properties: `, error);
+      console.error(`[DeviceMonitor ${this.wotEndpoint}] Failed to evaluate accuracy dynamically: `, error);
     }
   }
 }

--- a/backend/src/oracle/OracleManager.ts
+++ b/backend/src/oracle/OracleManager.ts
@@ -1,4 +1,3 @@
-import { deviceConfigs } from "../wot/deviceConfig";
 import { ContractService } from "./ContractService";
 import { DeviceMonitor } from "./DeviceMonitor";
 
@@ -11,36 +10,52 @@ export class OracleManager {
   }
 
   public async startAll(): Promise<void> {
-    console.log(`Starting monitors for ${deviceConfigs.length} devices`);
+    console.log(`[OracleManager] Syncing devices from the blockchain...`);
 
-    for (const config of deviceConfigs) {
-      const endpoint = `http://localhost:${config.port}/${config.id}`;
-      const deviceId = ContractService.computeDeviceId(endpoint);
+    const contract = this.contractService.getContractInstance();
+    const allDeviceIds = await contract.getAllDevices();
 
-      const monitor = new DeviceMonitor(endpoint, this.contractService, config);
-      await monitor.start()
-      this.monitors.set(deviceId, monitor);
+    for (const deviceId of allDeviceIds) {
+      const deviceData = await contract.devices(deviceId);
+      
+      if (deviceData.active) {
+        const wotEndpoint = deviceData.wotEndpoint;
+        
+        const monitor = new DeviceMonitor(wotEndpoint, this.contractService);
+        await monitor.start();
+        
+        this.monitors.set(deviceId, monitor);
+      }
     }
 
+    this.listenForNewDevices();
     this.listenForDeactivations();
-    console.log(`All monitors running`);
+    console.log(`[OracleManager] Sync complete. All active monitors running.`);
   }
 
-  public async stopAll(): Promise<void> {
-    console.log(`Stopping all monitors (${deviceConfigs.length} devices)`);
-    Array.from(this.monitors.values()).forEach((monitor) => monitor.stop());
+  private listenForNewDevices(): void {
+    const contract = this.contractService.getContractInstance();
+    
+    contract.on("DeviceEnrolled", async (deviceId: string, operator: string, wotEndpoint: string) => {
+      if (this.monitors.has(deviceId)) return; 
 
-    this.monitors.clear();
+      console.log(`[OracleManager] New device detected on-chain! Starting monitor for ${wotEndpoint}`);
+      
+      const monitor = new DeviceMonitor(wotEndpoint, this.contractService);
+      await monitor.start();
+      this.monitors.set(deviceId, monitor);
+    });
   }
 
   private listenForDeactivations(): void {
     const contract = this.contractService.getContractInstance();
     
-    contract.on("DeviceDeactivated", (deviceId: string) => {
+    contract.on("DeviceDeactivated", async (deviceId: string) => {
       const monitor = this.monitors.get(deviceId);
       if (monitor) {
-        monitor.markInactive();
-        console.log(`Monitor marked inactive for ${deviceId}.`);
+        await monitor.stop();
+        this.monitors.delete(deviceId);
+        console.log(`[OracleManager] Cleaned up monitor for deactivated device: ${deviceId}`);
       }
     });
   }

--- a/backend/src/wot/DeviceManager.ts
+++ b/backend/src/wot/DeviceManager.ts
@@ -1,17 +1,17 @@
-import { deviceConfigs } from "./deviceConfig";
+import { simulationProfiles } from "./deviceConfig";
 import { DeviceSimulator } from "./DeviceSimulator";
 
 export class DeviceManager {
   private devices: Map<string, DeviceSimulator> = new Map();
 
   public async startAll(): Promise<void> {
-    console.log(`\nStarting WoT device network (${deviceConfigs.length} devices)...`);
+    console.log(`\nStarting WoT device network (${simulationProfiles.length} generic devices)...`);
 
     await Promise.all(
-      deviceConfigs.map(async (config) => {
-        const device = new DeviceSimulator(config);
-        device.start();
-        this.devices.set(config.id, device);
+      simulationProfiles.map(async (profile) => {
+        const device = new DeviceSimulator(profile);
+        await device.start(); 
+        this.devices.set(profile.id, device);
       }));
 
     console.log(`\nWoT network online. Devices:`);

--- a/backend/src/wot/DeviceSimulator.ts
+++ b/backend/src/wot/DeviceSimulator.ts
@@ -1,55 +1,65 @@
-import { DeviceConfig } from "./deviceConfig";
 import { Servient } from "@node-wot/core";
 import { HttpServer } from "@node-wot/binding-http";
+import { SimulatorProfile } from "./deviceConfig";
 
 export class DeviceSimulator {
-  private config: DeviceConfig;
+  private profile: SimulatorProfile;
   private servient: Servient;
-  private thing: any = null; // inconsistent node-wot ExposedThing type?
+  private thing: any = null; 
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private isRunning: boolean = false;
 
-  private currentTemperature = 20;
-  private currentHumidity = 50;
   private sequenceNonce = 0;
+  private faultRate: number;
 
-  public constructor(config: DeviceConfig){
-    this.config = config;
-
+  public constructor(profile: SimulatorProfile) {
+    this.profile = profile;
     this.servient = new Servient();
-    this.servient.addServer(new HttpServer({ port: config.port }));
+    this.servient.addServer(new HttpServer({ port: profile.port }));
+
+    const isFaultyDevice = Math.random() > 0.5;
+    if (isFaultyDevice) {
+      this.faultRate = parseFloat((Math.random() * 0.35 + 0.05).toFixed(2));
+    } else {
+      this.faultRate = 0.0;
+    }
   }
 
   public async start(): Promise<void> {
     const WoT = await this.servient.start();
 
-    const td: any = {
-      title: `${this.config.id}`,
-      id: `urn:trustpulse:${this.config.id}`,
-      description: `Simulated ${this.config.deviceType} for TrustPulse network`,
-      properties: {
-        temperature: {
-          type: "number",
-          description: "Current temperature reading in Celsius",
-          unit: "celsius",
-          readOnly: true,
-          observable: false
-        },
-        humidity: {
-          type: "number",
-          description: "Current relative humidity reading",
-          unit: "percent",
-          readOnly: true,
-          observable: false
-        },
-        status: {
-          type: "string",
-          description: "Device operational status",
-          readOnly: true,
-          observable: false,
-          enum: ["online", "faulty"]
-        }
+    const dynamicProperties: any = {
+      heartbeatInterval: {
+        type: "number",
+        description: "The interval in milliseconds at which this device emits heartbeats",
+        readOnly: true,
+        observable: false
       },
+      status: {
+        type: "string",
+        description: "Device operational status",
+        readOnly: true,
+        observable: false,
+        enum: ["online", "faulty", "offline"]
+      }
+    };
+
+    for (const [key, propConfig] of Object.entries(this.profile.properties)) {
+      dynamicProperties[key] = {
+        type: propConfig.type,
+        readOnly: true,
+        observable: false
+      };
+      
+      if (propConfig.minimum !== undefined) dynamicProperties[key].minimum = propConfig.minimum;
+      if (propConfig.maximum !== undefined) dynamicProperties[key].maximum = propConfig.maximum;
+    }
+
+    const td: any = {
+      title: this.profile.id,
+      id: `urn:trustpulse:${this.profile.id}`,
+      description: `Simulated WoT device for TrustPulse network`,
+      properties: dynamicProperties,
       events: {
         heartbeat: {
           description: "Periodic liveness signal emitted by the device",
@@ -58,7 +68,7 @@ export class DeviceSimulator {
             properties: {
               timestamp: { type: "number" },
               deviceId: { type: "string" },
-              eventId: { type:  "number" }
+              eventId: { type: "number" }
             }
           }
         }
@@ -67,27 +77,19 @@ export class DeviceSimulator {
 
     this.thing = await WoT.produce(td);
 
-    this.thing?.setPropertyReadHandler("temperature", async () => {
-      return this.generateReading(
-        this.config.temperature.min,
-        this.config.temperature.max,
-        -50,
-        999
-      );
-    });
-
-    this.thing?.setPropertyReadHandler("humidity", async () => {
-      return this.generateReading(
-        this.config.humidity.min,
-        this.config.humidity.max,
-        -50,
-        999
-      );
-    });
-
     this.thing?.setPropertyReadHandler("status", async () => {
       return this.isRunning ? "online" : "offline";
     });
+
+    this.thing?.setPropertyReadHandler("heartbeatInterval", async () => {
+      return this.profile.heartbeatInterval;
+    });
+
+    for (const [key, propConfig] of Object.entries(this.profile.properties)) {
+      this.thing?.setPropertyReadHandler(key, async () => {
+        return this.generateReading(propConfig);
+      });
+    }
 
     await this.thing?.expose();
     this.isRunning = true;
@@ -95,8 +97,8 @@ export class DeviceSimulator {
     this.startHeartbeat();
 
     console.log(
-      `[${this.config.id}] Started on port ${this.config.port} ` +
-      `(faultRate: ${this.config.faultRate})`
+      `[${this.profile.id}] Simulator '${this.profile.title}' started on port ${this.profile.port} ` +
+      `(faultRate: ${this.faultRate})`
     );
   }
 
@@ -109,21 +111,21 @@ export class DeviceSimulator {
     }
 
     await this.servient.shutdown();
-    console.log(`[${this.config.id}] Stopped`);
+    console.log(`[${this.profile.id}] Stopped`);
   } 
 
   public setFaultRate(rate: number): void {
     if (rate < 0 || rate > 1) throw new Error("Fault rate must be between 0 and 1");
-    this.config.faultRate = rate;
-    console.log(`[${this.config.id}] Fault rate updated to ${rate}`);
+    this.faultRate = rate;
+    console.log(`[${this.profile.id}] Fault rate updated to ${rate}`);
   }
 
-  public getConfig(): DeviceConfig {
-    return { ...this.config };
+  public getProfile(): SimulatorProfile {
+    return { ...this.profile };
   }
 
   public getEndpoint(): string {
-    return `http://localhost:${this.config.port}`;
+    return `http://localhost:${this.profile.port}`;
   }
 
   private startHeartbeat(): void {
@@ -133,24 +135,33 @@ export class DeviceSimulator {
 
         this.thing.emitEvent("heartbeat", {
           timestamp: Date.now(),
-          deviceId: this.config.id,
+          deviceId: this.profile.id,
           eventId: this.sequenceNonce
         });
       }
-    }, this.config.heartbeatInterval);
+    }, this.profile.heartbeatInterval);
   }
 
-  private generateReading(normalMin: number, normalMax: number, faultMin: number, faultMax: number): number {
-    const isFaulty = Math.random() < this.config.faultRate;
-
-    if (isFaulty) {
-      return this.randomInRange(faultMin, faultMax);
+  private generateReading(propConfig: any): any {
+    if (propConfig.type === 'boolean') {
+      return Math.random() > 0.5;
     }
 
-    return parseFloat(this.randomInRange(normalMin, normalMax).toFixed(2));
-  }
+    if (propConfig.type === 'number') {
+      const min = propConfig.minimum ?? 0;
+      const max = propConfig.maximum ?? 100;
+      const isFaulty = Math.random() < this.faultRate;
 
-  private randomInRange(min: number, max: number): number {
-    return Math.random() * (max - min) + min;
+      if (isFaulty) {
+        const anomalyOffset = (max - min) * 1.5;
+        const outOfBoundsValue = Math.random() > 0.5 ? max + anomalyOffset : min - anomalyOffset;
+        return parseFloat(outOfBoundsValue.toFixed(2));
+      }
+
+      const safeValue = Math.random() * (max - min) + min;
+      return parseFloat(safeValue.toFixed(2));
+    }
+
+    return "unknown";
   }
 }

--- a/backend/src/wot/deviceConfig.ts
+++ b/backend/src/wot/deviceConfig.ts
@@ -1,50 +1,44 @@
-export interface DeviceConfig {
-  id: string;
-  port: number;
-  deviceType: string;
-  faultRate: number;
-  heartbeatInterval: number;
-  temperature: {
-    min: number;
-    max: number;
-  };
-  humidity: {
-    min: number;
-    max: number;
-  };
+export interface PropertyProfile {
+  type: 'number' | 'boolean' | 'string';
+  minimum?: number;
+  maximum?: number;
 }
 
-export const deviceConfigs: DeviceConfig[] = [
+export interface SimulatorProfile {
+  id: string;
+  port: number;
+  title: string;
+  heartbeatInterval: number;
+  properties: Record<string, PropertyProfile>;
+}
+
+export const simulationProfiles: SimulatorProfile[] = [
   {
     id: "sensor-01",
     port: 8081,
-    deviceType: "temperature-humidity-sensor",
-    faultRate: 0.05,
-    heartbeatInterval: 30000,
-    temperature: { min: 18, max: 26 },
-    humidity: { min: 40, max: 70 }
+    title: "Agricultural Weather Station",
+    heartbeatInterval: 10000,
+    properties: {
+      temperature: { type: 'number', minimum: -10, maximum: 50 },
+      humidity: { type: 'number', minimum: 0, maximum: 100 }
+    }
   },
   {
     id: "sensor-02",
     port: 8082,
-    deviceType: "temperature-humidity-sensor",
-    faultRate: 0.25,
-    heartbeatInterval: 30000,
-    temperature: { min: 18, max: 26 },
-    humidity: { min: 40, max: 70 }
+    title: "Industrial Pressure Valve",
+    heartbeatInterval: 8000,
+    properties: {
+      pressurePSI: { type: 'number', minimum: 200, maximum: 800 }
+    }
   },
   {
     id: "sensor-03",
     port: 8083,
-    deviceType: "temperature-humidity-sensor",
-    faultRate: 0.6,
-    heartbeatInterval: 30000,
-    temperature: { min: 18, max: 26 },
-    humidity: { min: 40, max: 70 }
+    title: "Smart Door Lock",
+    heartbeatInterval: 15000,
+    properties: {
+      isLocked: { type: 'boolean' }
+    }
   }
 ];
-
-export const PLAUSIBILITY_BOUNDS = {
-  temperature: { min: -10, max: 60 },
-  humidity: { min: 0, max: 100 }
-};

--- a/frontend/src/app/pages/operator/operator.ts
+++ b/frontend/src/app/pages/operator/operator.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, effect, inject } from '@angular/core';
+import { Component, effect, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { WalletService } from '../../../common/services/wallet.service';
 import { ContractService } from '../../../common/services/contract.service';
@@ -79,6 +79,14 @@ export class OperatorComponent {
     this.enrolledDeviceId = null;
 
     try {
+      const validation = await this.validateThingDescription(this.deviceEndpoint);
+      
+      if (!validation.valid) {
+        this.enrollState = 'error';
+        this.enrollError = validation.reason || 'Invalid Thing Description.';
+        return; 
+      }
+
       await this.contract.enrollDevice(this.deviceEndpoint, this.deviceType);
 
       const { ethers } = await import('ethers');
@@ -92,6 +100,43 @@ export class OperatorComponent {
     } catch (error: any) {
       this.enrollState = 'error';
       this.enrollError = this.parseError(error);
+    }
+  }
+
+  private async validateThingDescription(endpoint: string): Promise<{ valid: boolean; reason?: string }> {
+    try {
+      const response = await fetch(endpoint);
+      if (!response.ok) return { valid: false, reason: `HTTP Status: ${response.status}` };
+
+      const td = await response.json();
+      if (!td || typeof td !== 'object' || !td.properties) {
+        return { valid: false, reason: "Invalid TD: Missing 'properties' schema." };
+      }
+
+      const hbSchema = td.properties['heartbeatInterval'];
+      if (!hbSchema) {
+        return { valid: false, reason: "Invalid TD: Missing required 'heartbeatInterval' property." };
+      }
+      if (hbSchema.type !== 'number' && hbSchema.type !== 'integer') {
+        return { valid: false, reason: "Invalid TD: 'heartbeatInterval' must be a numeric type." };
+      }
+
+      for (const [propName, propSchema] of Object.entries<any>(td.properties)) {
+        if (propSchema.type === 'number' || propSchema.type === 'integer') {
+          if (propName !== 'heartbeatInterval') {
+            if (propSchema.minimum === undefined || propSchema.maximum === undefined) {
+              return { valid: false, reason: `Invalid Schema: Numeric property '${propName}' is missing min/max bounds.` };
+            }
+            if (propSchema.minimum >= propSchema.maximum) {
+              return { valid: false, reason: `Invalid Schema: '${propName}' min >= max.` };
+            }
+          }
+        }
+      }
+
+      return { valid: true };
+    } catch (error) {
+      return { valid: false, reason: "Network error or invalid JSON." };
     }
   }
 


### PR DESCRIPTION
This PR transitions the platform from hardcoded sensor logic to a fully generic, decentralized Web of Things (WoT) architecture. Oracles are now decoupled from local configurations and derive their consensus rules entirely from W3C Thing Descriptions (TD). 

**Key Changes:**
* **Dynamic Oracle Network:** Oracles now dynamically read properties, `min`/`max` bounds, and `heartbeatInterval` directly from the device's TD. Local `deviceConfig` dependencies have been removed.
* **Generic Simulators:** Overhauled `DeviceSimulator` to build devices dynamically from `SimulatorProfile` blueprints. Introduced randomized internal `faultRates` for automated chaos testing.
* **Strict Pre-flight Validation:** Added off-chain validation (frontend/API) to reject device enrollments if the TD violates schema rules (e.g., missing numeric bounds or heartbeat intervals).
* **Resilience & Bug Fixes:** 
  * Fixed the "ghost monitor" race condition in `OracleManager` caused by overlapping blockchain events.
  * Added exception handling for implicit `@node-wot` schema violations (e.g., out-of-bounds anomalies).
  * Enforced standard-compliant URNs for device IDs to fix HTTP routing bugs.